### PR TITLE
testing if we can use spack base

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,28 @@
+name: "Build Containers on Update"
+
+on:
+  pull_request: []
+#    branches:
+#      - update-*
+      
+jobs:
+  spack-containerize:
+    runs-on: ubuntu-latest
+    container:
+      image: spack/github-actions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2        
+      - name: Log the node version
+        run: |
+           # Try replacing 
+           package=$(echo "${GITHUB_BRANCH/update-/}")
+           spack containerize $package
+           spack containerize $package > "$GITHUB_WORKSPACE/Dockerfile.${package}"
+           
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Look to see if we have file from container
+        run: |
+           ls $GITHUB_WORKSPACE


### PR DESCRIPTION
This is just testing if we can easily grab an existing spack container to run the containerize command, and then save the file somewhere in the GitHub workspace so that it can be seen by a subsequent step. The reason is because I think it's unlikely we can build a docker container inside the first one.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>